### PR TITLE
Decoupled `Walk.gd` from character-specific logic.

### DIFF
--- a/Objects/Characters/Godzilla.tscn
+++ b/Objects/Characters/Godzilla.tscn
@@ -12,12 +12,14 @@
 [ext_resource type="Texture2D" uid="uid://cp7yo85faut6q" path="res://Sprites/Characters/Godzilla/punch2.png" id="4_7jbwm"]
 
 [sub_resource type="GDScript" id="GDScript_5gjb6"]
-script/source = "extends Node2D
+script/source = "extends PlayerSkin
 
-@onready var parent: PlayerCharacter = get_parent()
 @onready var offset_y: float = $Body/Head.position.y
 @onready var body := $Body
 @onready var head := $Body/Head
+
+func _ready() -> void:
+	walk_frame_speed = 9
 
 func _process(_delta: float) -> void:
 	if body.animation == \"Walk\":
@@ -29,11 +31,20 @@ func _process(_delta: float) -> void:
 		if head.animation == \"Walk\":
 			head.frame = body.frame
 
+func walk_process() -> void:
+	common_ground_attacks()
+	if player.animation_player.current_animation == \"Crouch\" \\
+		and player.inputs_pressed[PlayerCharacter.Inputs.B]:
+			player.use_attack(PlayerCharacter.Attack.TAIL_WHIP)
+	if player.inputs_pressed[PlayerCharacter.Inputs.START] \\
+		and player.power.value >= 6 * 8:
+		player.use_attack(PlayerCharacter.Attack.HEAT_BEAM)
+
 func _on_animation_started(anim_name: StringName) -> void:
 	var size := 56
 	if anim_name == \"Crouch\" or anim_name == \"TailWhip\":
 		size = 40
-	parent.set_collision(Vector2(20, size),
+	player.set_collision(Vector2(20, size),
 		Vector2(0, -1 + (56 - size) / 2))
 "
 

--- a/Objects/Characters/Mothra.tscn
+++ b/Objects/Characters/Mothra.tscn
@@ -1,7 +1,11 @@
-[gd_scene load_steps=17 format=3 uid="uid://cqrpbxce3xquu"]
+[gd_scene load_steps=18 format=3 uid="uid://cqrpbxce3xquu"]
 
 [ext_resource type="Texture2D" uid="uid://nhpib3frkqrg" path="res://Sprites/Characters/Mothra/hurt.png" id="1_64xd3"]
 [ext_resource type="Texture2D" uid="uid://dh0gtj20jut25" path="res://Sprites/Characters/Mothra/idle.png" id="1_f6h4m"]
+
+[sub_resource type="GDScript" id="GDScript_wq6ak"]
+script/source = "extends PlayerSkin
+"
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_w0xxw"]
 atlas = ExtResource("1_64xd3")
@@ -172,6 +176,7 @@ _data = {
 }
 
 [node name="Mothra" type="Node2D"]
+script = SubResource("GDScript_wq6ak")
 
 [node name="Body" type="AnimatedSprite2D" parent="."]
 position = Vector2(-12, -28)

--- a/Objects/Characters/Skin.tscn
+++ b/Objects/Characters/Skin.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=3 uid="uid://b5my8r3e30dr4"]
+
+[ext_resource type="Script" path="res://Scripts/Objects/Characters/Skin.gd" id="1_68e6j"]
+
+[node name="Skin" type="Node2D"]
+script = ExtResource("1_68e6j")
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]

--- a/Scripts/Objects/Characters/PlayerCharacter.gd
+++ b/Scripts/Objects/Characters/PlayerCharacter.gd
@@ -72,7 +72,7 @@ var xp := 0
 var save_position: Array[Vector2]
 
 var body: AnimatedSprite2D
-var skin: Node2D
+var skin: PlayerSkin
 var animation_player: AnimationPlayer
 
 signal intro_ended

--- a/Scripts/Objects/Characters/Skin.gd
+++ b/Scripts/Objects/Characters/Skin.gd
@@ -1,0 +1,18 @@
+class_name PlayerSkin
+extends Node2D
+
+@onready var player: PlayerCharacter = get_parent()
+
+## Stuff for Walk.gd
+
+var walk_frame_speed := 0
+
+func walk_process() -> void:
+	pass
+
+func common_ground_attacks() -> void:
+	if player.inputs_pressed[PlayerCharacter.Inputs.A]:
+		player.use_attack(PlayerCharacter.Attack.PUNCH)
+	if player.animation_player.current_animation != "Crouch" \
+		and player.inputs_pressed[PlayerCharacter.Inputs.B]:
+			player.use_attack(PlayerCharacter.Attack.KICK)

--- a/Scripts/Objects/Characters/Walk.gd
+++ b/Scripts/Objects/Characters/Walk.gd
@@ -4,6 +4,8 @@ extends State
 # This state consists of not only walking but also crouching and jumping.
 # This state also includes the movement for flying characters.
 
+@onready var player := parent as PlayerCharacter
+
 var walk_frame := 0.0
 var walk_frames := 0
 var walk_frame_speed := 0
@@ -12,76 +14,66 @@ var jumping := false
 var jump_speed := -2 * 60
 
 func state_init() -> void:
-	if not parent.is_flying():
-		walk_frames = parent.body.sprite_frames.get_frame_count("Walk")
 	
-	match parent.character:
-		PlayerCharacter.Type.GODZILLA:
-			walk_frame_speed = 9
-			# # You can change the jumping speed for your character like this
-			# jump_speed = -1 * 60
+	if not player.is_flying():
+		walk_frames = player.body.sprite_frames.get_frame_count("Walk")
+
+	# This
+	walk_frame_speed = player.skin.walk_frame_speed
+	
+	# Instead of this :)
+	#match player.character:
+		#PlayerCharacter.Type.GODZILLA:
+			#walk_frame_speed = 9
+			## # You can change the jumping speed for your character like this
+			## jump_speed = -1 * 60
+		#PlayerCharacter.Type.NOTBARAGON:
+			#walk_frame_speed = 6
 
 func _process(delta: float) -> void:
 	move(delta)
-	
-	# Attacks
-	match parent.character:
-		PlayerCharacter.Type.GODZILLA:
-			common_ground_attacks()
-			if parent.animation_player.current_animation == "Crouch" \
-				and parent.inputs_pressed[PlayerCharacter.Inputs.B]:
-					parent.use_attack(PlayerCharacter.Attack.TAIL_WHIP)
-			if parent.inputs_pressed[PlayerCharacter.Inputs.START] \
-				and parent.power.value >= 6 * 8:
-				parent.use_attack(PlayerCharacter.Attack.HEAT_BEAM)
-	
-func common_ground_attacks() -> void:
-	if parent.inputs_pressed[PlayerCharacter.Inputs.A]:
-		parent.use_attack(PlayerCharacter.Attack.PUNCH)
-	if parent.animation_player.current_animation != "Crouch" \
-		and parent.inputs_pressed[PlayerCharacter.Inputs.B]:
-			parent.use_attack(PlayerCharacter.Attack.KICK)
+	player.skin.walk_process()
 
 func move(delta: float) -> void:
-	var dirx: float = signf(parent.inputs[PlayerCharacter.Inputs.XINPUT])
+	var dirx: float = signf(player.inputs[PlayerCharacter.Inputs.XINPUT])
 	if dirx:
-		parent.velocity.x = parent.move_speed * dirx
+		player.velocity.x = player.move_speed * dirx
 		
-		if parent.allow_direction_changing:
-			parent.direction = int(signf(dirx))
+		if player.allow_direction_changing:
+			player.direction = int(signf(dirx))
 			
 		walk_frame = wrapf(
-			walk_frame + walk_frame_speed * delta * dirx * parent.direction,
+			walk_frame + walk_frame_speed * delta * dirx * player.direction,
 			0, walk_frames)
 			
-		if parent.body.animation == "Walk":
-			parent.body.frame = int(walk_frame)
+		if player.body.animation == "Walk":
+			player.body.frame = int(walk_frame)
 	else:
-		parent.velocity.x = 0
+		player.velocity.x = 0
 		
-	var diry: float = parent.inputs[PlayerCharacter.Inputs.YINPUT]
+	var diry: float = player.inputs[PlayerCharacter.Inputs.YINPUT]
 	
 	# Jump!
-	if parent.is_on_floor() and diry < -0.4:
-		parent.velocity.y = jump_speed
+	if player.is_on_floor() and diry < -0.4:
+		player.velocity.y = jump_speed
 		jumping = true
 	
 	# Variable jump height
-	if not parent.is_on_floor() and jumping:
-		if diry < -0.4 and parent.velocity.y < -1.95 * 60:
-			parent.velocity.y -= 216 * delta
-		if parent.velocity.y < 0 and diry >= -0.4:
+	if not player.is_on_floor() and jumping:
+		if diry < -0.4 and player.velocity.y < -1.95 * 60:
+			player.velocity.y -= 216 * delta
+		if player.velocity.y < 0 and diry >= -0.4:
 			jumping = false
-			parent.velocity.y = 0
+			player.velocity.y = 0
 	
 	# Crouch
-	if diry > 0.4 and parent.body.sprite_frames.has_animation("Crouch"):
-		if parent.animation_player.current_animation == "Walk"\
-			or parent.animation_player.current_animation == "":
-			parent.animation_player.play("Crouch")
+	if diry > 0.4 and player.body.sprite_frames.has_animation("Crouch"):
+		if player.animation_player.current_animation == "Walk"\
+			or player.animation_player.current_animation == "":
+			player.animation_player.play("Crouch")
 
-	if diry <= 0.4 and parent.animation_player.current_animation == "Crouch":
-		parent.animation_player.play("RESET")
+	if diry <= 0.4 and player.animation_player.current_animation == "Crouch":
+		player.animation_player.play("RESET")
 
 func reset() -> void:
 	walk_frame = 0


### PR DESCRIPTION
Added `Skin.tscn` as a holder of that logic, and made `Godzilla.tscn` and `Mothra.tscn` inherit it, moved godzilla-logic from `Walk.gd` to its skin.

As of now class name is different (`PlayerSkin`) due to name collision with native class `Skin`. Should be fixed.